### PR TITLE
Contingencies fix

### DIFF
--- a/src/constants/listOperations.js
+++ b/src/constants/listOperations.js
@@ -841,7 +841,7 @@ function equipUpgradeToOne(list, unitIndex, upgradeIndex, upgradeId) {
     list.units.splice(unitIndex + 1, 0, newUnit);
     list.unitObjectStrings.splice(unitIndex + 1, 0, newUnit.unitObjectString);
   }
-  list = decrementUnit(list, unitIndex);
+  list = decrementUnit(list, unitIndex, true);
   return consolidate(list);
 }
 
@@ -932,12 +932,15 @@ function incrementUnit(list, index) {
   return consolidate(list);
 }
 
-function decrementUnit(list, index) {
+function decrementUnit(list, index, isModification=false) {
   const unitObject = list.units[index];
   if (unitObject.count === 1) {
     const unitCard = cards[unitObject.unitId];
-    if (unitCard.keywords.includes('Contingencies')) {
-      list.contingencies = [];
+    // TODO - this will probably break if a faction gets 2 Contingencies units
+    if (unitCard.keywords.includes('Contingencies')){
+      if(!isModification){ // indicates there's still a copy of this guy out there
+        list.contingencies = [];
+      }
     }
     list.unitObjectStrings = deleteItem(list.unitObjectStrings, index);
     list.units = deleteItem(list.units, index);
@@ -1395,7 +1398,7 @@ function unequipUpgrade(list, action, unitIndex, upgradeIndex) {
         list.units.splice(unitIndex + 1, 0, newUnit);
         list.unitObjectStrings.splice(unitIndex + 1, 0, newUnit.unitObjectString);
       }
-      list = decrementUnit(list, unitIndex);
+      list = decrementUnit(list, unitIndex, true);
       return consolidate(list);
     }
     list = unequip(list, unitIndex, upgradeIndex);

--- a/src/constants/listOperations.js
+++ b/src/constants/listOperations.js
@@ -904,6 +904,8 @@ function addUnit(list, unitId, stackSize = 1) {
   const unitCard = cards[unitId];
   const unitIndex = findUnitHash(list, unitId);
 
+  // TODO TODO - this  will break stuff again if a list can have 2 units with Contingencies
+  // Should set list.contingencies=[] by default and let consolidate handle the show/no-show/emptying of it
   if (unitCard.keywords.includes('Contingencies')) {
     if (!list.contingencies) list.contingencies = [];
   }

--- a/src/constants/listOperations.js
+++ b/src/constants/listOperations.js
@@ -84,6 +84,12 @@ function rehashList(list) {
   return list;
 }
 
+/**
+ * Lots of various reduction and housekeeping things. 
+ * E.g. remove Contingencies deck if you no longer have
+ * @param {} list 
+ * @returns 
+ */
 function consolidate(list) {
   let hasContingencyKeyword = false;
   list.hasFieldCommander = false;
@@ -841,7 +847,7 @@ function equipUpgradeToOne(list, unitIndex, upgradeIndex, upgradeId) {
     list.units.splice(unitIndex + 1, 0, newUnit);
     list.unitObjectStrings.splice(unitIndex + 1, 0, newUnit.unitObjectString);
   }
-  list = decrementUnit(list, unitIndex, true);
+  list = decrementUnit(list, unitIndex);
   return consolidate(list);
 }
 
@@ -932,16 +938,9 @@ function incrementUnit(list, index) {
   return consolidate(list);
 }
 
-function decrementUnit(list, index, isModification=false) {
+function decrementUnit(list, index) {
   const unitObject = list.units[index];
   if (unitObject.count === 1) {
-    const unitCard = cards[unitObject.unitId];
-    // TODO - this will probably break if a faction gets 2 Contingencies units
-    if (unitCard.keywords.includes('Contingencies')){
-      if(!isModification){ // indicates there's still a copy of this guy out there
-        list.contingencies = [];
-      }
-    }
     list.unitObjectStrings = deleteItem(list.unitObjectStrings, index);
     list.units = deleteItem(list.units, index);
   } else {
@@ -1398,7 +1397,7 @@ function unequipUpgrade(list, action, unitIndex, upgradeIndex) {
         list.units.splice(unitIndex + 1, 0, newUnit);
         list.unitObjectStrings.splice(unitIndex + 1, 0, newUnit.unitObjectString);
       }
-      list = decrementUnit(list, unitIndex, true);
+      list = decrementUnit(list, unitIndex);
       return consolidate(list);
     }
     list = unequip(list, unitIndex, upgradeIndex);


### PR DESCRIPTION
Issue was that a decrement check was deleting contingencies. Unit upgrade mods create a new copy, change upgrades, then delete old copy. Removing the 'unit' copy before replacing it w updated one was removing contingencies. Remove Contingencies check there and let consolidate() handle it. 

Leave a similar check inside Addunit for now because I can't quite nail down where a new list gets initialized. Ideally, list.contingencies would never be null and just change based on numContingencies.